### PR TITLE
replace use of deprecated jira api - but compilation issue

### DIFF
--- a/src/Jira.hs
+++ b/src/Jira.hs
@@ -17,7 +17,7 @@ import Data.Maybe
 import Data.Time
 import Data.Time.Format
 import Text.Printf
-import Network.HTTP.Conduit
+import Network.HTTP.Simple
 import Data.Aeson
 import Control.Monad.Trans.Resource (runResourceT)
 import Data.ByteString.Char8 (ByteString(..), pack)
@@ -36,24 +36,41 @@ data WorkLog = WorkLog Day Issue HoursWorked
 instance Show WorkLog where
   show (WorkLog d i h) = printf "%s - %s - %.1f hours" (show d) i h
 
-data WorkLogJson = WorkLogJson { timeSpentSeconds :: Float
+data IssueJson = IssueJson { key :: String } deriving Generic
+instance FromJSON IssueJson
+instance ToJSON IssueJson
+
+data AuthorJson = AuthorJson { name :: String } deriving Generic
+instance FromJSON AuthorJson
+instance ToJSON AuthorJson
+
+data WorkLogJson = WorkLogJson { issue            :: IssueJson
                                , dateStarted      :: String
-                               } deriving (Generic)
+                               , timeSpentSeconds :: Float
+                               , author           :: AuthorJson
+                               } deriving Generic
 instance FromJSON WorkLogJson
+instance ToJSON WorkLogJson
+--  toJSON = object [ "issue" .= object [ "key" .= issue ]
+--                  , "dateStarted" .= dateStarted
+--                  , "timeSpentSeconds" .= timeSpentSeconds
+--                  , "author" .= object [ "name" .= author ]
+--                  ]
 
 
+worklogsUrl :: Config -> String
+worklogsUrl conf = parseUrl $ printf "https://%s/rest/tempo-timesheets/3/worklogs" (getJiraHost conf)
 
 getTimeLogged :: Config -> Day -> Day -> IO (Map.Map Day HoursWorked)
 getTimeLogged conf s e = do
-  request'' <- parseUrl $ printf "https://%s/rest/tempo-timesheets/3/worklogs" (getJiraHost conf)
-  let request' = applyBasicAuth (getJiraUser conf) (getJiraPassword conf) request''
+  let request' = applyBasicAuth (getJiraUser conf) (getJiraPassword conf) (worklogsUrl conf)
       params = [("dateFrom", Just $ ansidatefmt s), ("dateTo", Just $ ansidatefmt e)]
       request = setQueryString params request'
   manager <- newManager tlsManagerSettings
   response <- runResourceT $ httpLbs request manager
   let maybeJsonWorklogs = decode (responseBody response) :: Maybe [WorkLogJson]
       jsonWorkLogs  = fromJust maybeJsonWorklogs
-      worklogsAsPairs = map (\(WorkLogJson s d) -> (parseIsoDate d, s/3600.0)) jsonWorkLogs
+      worklogsAsPairs = map (\(WorkLogJson i d t a) -> (parseIsoDate d, t/3600.0)) jsonWorkLogs
       pairsByDate = L.groupBy ((==) `on` fst) worklogsAsPairs
       worklogsByDate = foldl (\m ws@((d,_):_) -> Map.insert d (map snd ws) m) Map.empty pairsByDate
   return $ Map.map sum worklogsByDate
@@ -63,21 +80,18 @@ logWork :: Config -> [WorkLog] -> IO ()
 logWork conf ws = mapM_ (logOne conf) ws
 
 logOne :: Config -> WorkLog -> IO ()
-logOne conf (WorkLog d i h) = do
-  request'' <- parseUrl $ issueUrl (getJiraHost conf) i
-  let request' = applyBasicAuth (getJiraUser conf) (getJiraPassword conf) request''
-      params = [("time", pack.show $ h), ("user", getJiraUser conf), ("date", datefmt d), ("ansidate", ansidatefmt d)]
-      request = urlEncodedBody params request'
+logOne conf (WorkLog day issue hours) = do
+  let json = WorkLogJson (IssueJson issue) (ansidatefmt day) (hours*3600.0) (AuthorJson (getJiraUser conf))
+      request' = applyBasicAuth (getJiraUser conf) (getJiraPassword conf) (worklogsUrl conf)
+      request = (parseRequest request')
+                {
+                  method = "POST"
+                , requestBody = (RequestBodyLBS (encode json))
+                }
   manager <- newManager tlsManagerSettings
   runResourceT $ do
     response <- http request manager
     return ()
 
-datefmt :: Day -> ByteString
-datefmt = pack . formatTime defaultTimeLocale "%d/%b/%y"
-
 ansidatefmt :: Day -> ByteString
-ansidatefmt = pack . formatTime defaultTimeLocale "%Y-%m-%d"
-
-issueUrl :: String -> Issue -> String
-issueUrl host issue = printf "https://%s/rest/tempo-rest/1.0/worklogs/%s" host issue
+ansidatefmt = pack . formatTime defaultTimeLocale "%Y-%m-%dT%T.000"

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,7 @@ packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps: [HTTP-Simple-0.2]
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/tempo.cabal
+++ b/tempo.cabal
@@ -31,6 +31,7 @@ library
                      , ConfigFile
                      , mtl
                      , http-conduit
+                     , HTTP-Simple
                      , resourcet
                      , bytestring
                      , base64-bytestring


### PR DESCRIPTION
I shamefully admit I failed to compile this because stack "Could not find module ‘Network.HTTP.Simple’"

but maybe we can finish this together :) :)